### PR TITLE
fix allow changing shared function ID

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -423,7 +423,7 @@ export function useSharedState<T>(
       ctx.unsubFromRoom(uniqueStateID, "State")
       internalEmitter.removeListener(internalEmitterID, setState)
     }
-  }, [ctx])
+  }, [ctx, uniqueStateID])
 
   return [state, setter]
 }

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -469,7 +469,7 @@ export function useSharedFunction<T extends any[]>(
       ctx.unsubFromRoom(uniqueFunctionID, "Function")
       internalEmitter.removeListener(internalEmitterID, callerWrapper)
     }
-  }, [ctx])
+  }, [ctx, uniqueFunctionID])
 
   return caller
 }


### PR DESCRIPTION
without this it's impossible to change the function (e.g. to add a lazily loaded user ID) after the initial call